### PR TITLE
gemspec: Allow generation of gem using Ruby 1.9

### DIFF
--- a/asciidoctor-latex.gemspec
+++ b/asciidoctor-latex.gemspec
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-require File.expand_path('lib/asciidoctor/latex/version', __dir__)
+require File.expand_path('lib/asciidoctor/latex/version', File.dirname(__FILE__))
 
 Gem::Specification.new do |s|
   s.name          = 'asciidoctor-latex'


### PR DESCRIPTION
The __dir__ is only available in Ruby 2.0 or newer. To allow the 
generation of gem using older version of Ruby we can rely on
__FILE__ and deduce the directory name for loading it.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>