### PR TITLE
Add support for bold text

### DIFF
--- a/lib/asciidoctor/latex/node_processors.rb
+++ b/lib/asciidoctor/latex/node_processors.rb
@@ -753,8 +753,7 @@ module Asciidoctor
       # warn ["Node:".blue, "#{self.node_name}".cyan,  "type[#{self.type}], ".green + " text: #{self.text}"].join(" ") if $VERBOSE
       case self.type
         when :strong
-          #"\\textbf\{#{self.text}\}"
-          self.text
+          "\\textbf\{#{self.text}\}"
         when :emphasis
           "\\emph\{#{self.text}\}"
         when :asciimath

--- a/test/examples/tex/block_table.tex
+++ b/test/examples/tex/block_table.tex
@@ -122,7 +122,7 @@ Cell in column 1, row 1 & Cell in column 2, row 1 & Cell in column 3, row 1 \\
 \begin{center}
 \begin{tabular}{|c|c|c|c|c|c|c|}
 \hline
-\ & \emph{Emphasized text} & Styled like a header & \unknown\{Literal block\} & {\tt Monospaced text} & Strong text & \unknown\{Verse block\} \\
+\ & \emph{Emphasized text} & Styled like a header & \unknown\{Literal block\} & {\tt Monospaced text} & \textbf{Strong text} & \unknown\{Verse block\} \\
 \hline
 \end{tabular}
 \end{center}
@@ -177,7 +177,7 @@ This content spans three columns (3{plus}) and is centered horizontally ({caret}
 {\tt This content is duplicated across two columns.
 } & {\tt This content is duplicated across two columns.
 } \\
-This cell spans 3 rows. The content is centered horizontally, aligned to the bottom of the cell, and strong. & \emph{This content is emphasized.} \\
+\textbf{This cell spans 3 rows. The content is centered horizontally, aligned to the bottom of the cell, and strong.} & \emph{This content is emphasized.} \\
 \unknown\{This content is aligned to the top of the cell and literal.\} \\
 \unknown\{This cell contains a verse
 that may one day expound on the

--- a/test/examples/tex/inline_anchor.tex
+++ b/test/examples/tex/inline_anchor.tex
@@ -8,7 +8,7 @@
 \href{view-source:asciidoctor.org}{Asciidoctor homepage}
 
 %== .basic_with_role ==%
-\href{http://discuss.asciidoctor.org/}{mailing list}
+\href{http://discuss.asciidoctor.org/}{\textbf{mailing list}}
 
 %== .xref ==%
 The section \hyperlink{page-break}{} describes how to add a page break.

--- a/test/examples/tex/inline_quoted.tex
+++ b/test/examples/tex/inline_quoted.tex
@@ -7,10 +7,10 @@
 \emph{chunky bacon}
 
 %== .strong ==%
-chunky bacon
+\textbf{chunky bacon}
 
 %== .strong_with_role ==%
-chunky bacon
+\textbf{chunky bacon}
 
 %== .monospaced ==%
 {\tt hello world!}
@@ -55,7 +55,7 @@ $C = \alpha + \beta Y^{\gamma} + \epsilon$
 \emph{chunky bacon}
 
 %== .mixed_monospace_bold_italic ==%
-{\tt \emph{monospace bold italic phrase}} and le{\tt \emph{tt}}ers
+{\tt \textbf{\emph{monospace bold italic phrase}}} and le{\tt \textbf{\emph{tt}}}ers
 
 %== .asciimath ==%
 <div class="paragraph">


### PR DESCRIPTION
Convert `*example*` to `\textbf{example}`. For some reason, the code was present, but commented out. I adapted the tests as well. All tests that passed previously, still pass.