### PR TITLE
how to install copied from rubygems

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -203,7 +203,7 @@ endif::[]
 
 === From Rubygems
 
-Run `gem install asciidoc-latex` to install from
+Run `gem install asciidoctor-latex --pre` to install from
 https://rubygems.org/gems/asciidoctor-latex[RubyGems.org].
 See the https://github.com/asciidoctor/asciidoctor-latex/blob/master/CHANGELOG.adoc[change log]
 for a list of updates.


### PR DESCRIPTION
Howto installation did not work, so I copied the information from rubygems.https://rubygems.org/gems/asciidoctor-latex