### PR TITLE
resolves #59 use correct property to get label (aka id) of ref

### DIFF
--- a/lib/asciidoctor/latex/node_processors.rb
+++ b/lib/asciidoctor/latex/node_processors.rb
@@ -813,7 +813,7 @@ module Asciidoctor
         when :link
           $tex.macro 'href', self.target, self.text
         when :ref
-          $tex.macro 'label', self.text.gsub(/\[(.*?)\]/, "\\1")
+          $tex.macro 'label', (self.id || self.target)
         when :xref
           $tex.macro 'hyperlink', refid.tex_normalize, reftext
         else


### PR DESCRIPTION
The converter for the inline ref was extracting the label (aka id) from the text. However, the label is already available as a property. In Asciidoctor < 1.5.6, the label was stored on the `target` property. Although still supported, the preferred property is `id`. I have set up to converter look at the `id` property first and fallback to the target.

This fixes a NilClass exception when using Asciidoctor LaTeX with Asciidoctor >= 1.5.6.