### PR TITLE
[FEATURE] Support for generated index in tex output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ mytest/
 /Gemfile.lock
 /pkg/
 /.bundle/
+/vendor/
 /.ruby-gemset
 /.ruby-version
 /.yardoc/

--- a/data/preamble_article.tex
+++ b/data/preamble_article.tex
@@ -52,3 +52,5 @@
 \DeclareGraphicsExtensions{.png, .jpg, jpeg, .pdf}
 
 %% \DeclareGraphicsRule{.tif}{png}{.png}{`convert #1 `dirname #1`/`basename #1 .tif`.png}
+
+\makeindex

--- a/data/preamble_book.tex
+++ b/data/preamble_book.tex
@@ -54,3 +54,5 @@
 \DeclareGraphicsExtensions{.png, .jpg, jpeg, .pdf}
 
 %% \DeclareGraphicsRule{.tif}{png}{.png}{`convert #1 `dirname #1`/`basename #1 .tif`.png}
+
+\makeindex

--- a/lib/asciidoctor/latex/converter.rb
+++ b/lib/asciidoctor/latex/converter.rb
@@ -529,7 +529,7 @@ module Asciidoctor::LaTeX
 
     TOP_TYPES = %w(document section)
     LIST_TYPES = %w(dlist olist ulist)
-    INLINE_TYPES = %w(inline_anchor inline_break inline_footnote inline_quoted inline_callout)
+    INLINE_TYPES = %w(inline_anchor inline_break inline_footnote inline_quoted inline_callout inline_indexterm)
     BLOCK_TYPES = %w(admonition listing literal page_break paragraph stem pass open quote \
      example floating_title image click preamble sidebar verse toc)
     OTHER_TYPES = %w(environment table)

--- a/lib/asciidoctor/latex/node_processors.rb
+++ b/lib/asciidoctor/latex/node_processors.rb
@@ -174,7 +174,14 @@ module Asciidoctor
       id ="_#{self.title.downcase.gsub(' ', '_')}"
       heading = "\\#{tagname}#{tagsuffix}\{#{self.title}\}"
       heading = $tex.hypertarget id, heading
-      value = "#{heading}\n#{self.content}"
+
+      if self.sectname == 'index'
+        value = $tex.macro 'renewcommand', '\\indexname', self.title
+        value += $tex.hypertarget id, '\\printindex'
+      else
+        value = "#{heading}\n#{self.content}"
+      end
+
       value
     end
   end
@@ -734,6 +741,8 @@ module Asciidoctor
         self.inline_footnote_process
       when 'inline_callout'
         self.inline_callout_process
+      when 'inline_indexterm'
+        self.inline_indexterm_process
       else
         ""
       end
@@ -821,6 +830,16 @@ module Asciidoctor
 
     def inline_callout_process
       # warn "Please implement me! (inline_callout_process)".red if $VERBOSE
+    end
+
+    def inline_indexterm_process
+      case self.type
+      when :visible
+        output = $tex.macro 'index', self.text
+        output += self.text
+      else
+        $tex.macro 'index', self.attributes['terms'].join('!')
+      end
     end
 
   end

--- a/test/examples/adoc/index_section.adoc
+++ b/test/examples/adoc/index_section.adoc
@@ -1,0 +1,3 @@
+// .index_listing
+[index]
+== Auflistung

--- a/test/examples/adoc/inline_indexterm.adoc
+++ b/test/examples/adoc/inline_indexterm.adoc
@@ -1,0 +1,12 @@
+// .flow_index
+The Lady of the Lake, her arm clad in the purest shimmering samite,
+held aloft Excalibur from the bosom of the water,
+signifying by divine providence that I, ((Arthur)), 
+was to carry indexterm2:[Excalibur].
+That is why I am your king. Shut up! Will you shut up?!
+Burn her anyway! I'm not a witch.
+Look, my liege! We found them.
+
+// .concealed_index
+Lancelot was one (((units,numbers,one))) of the Knights of the Round Table.
+indexterm:[knight, Knight of the Round Table, Lancelot]

--- a/test/examples/tex/index_section.tex
+++ b/test/examples/tex/index_section.tex
@@ -1,0 +1,2 @@
+%== .index_listing ==%
+\renewcommand{\indexname}{Auflistung}\hypertarget{x-auflistung}{\printindex}

--- a/test/examples/tex/inline_indexterm.tex
+++ b/test/examples/tex/inline_indexterm.tex
@@ -1,0 +1,12 @@
+%== .flow_index ==%
+The Lady of the Lake, her arm clad in the purest shimmering samite,
+held aloft Excalibur from the bosom of the water,
+signifying by divine providence that I, \index{Arthur}Arthur,
+was to carry \index{Excalibur}Excalibur.
+That is why I am your king. Shut up! Will you shut up?!
+Burn her anyway! I’m not a witch.
+Look, my liege! We found them.
+
+%== .concealed_index ==%
+Lancelot was one \index{units!numbers!one} of the Knights of the Round Table.
+\index{knight!Knight of the Round Table!Lancelot}


### PR DESCRIPTION
Implemented `.tex` output for index generation. This should be feature-equivalent to what `asciidoctor-pdf` is doing (see https://github.com/asciidoctor/asciidoctor-pdf/pull/562).

Note that this does not honor the level of the "index" section, so

    [index]
    == My Index

and

    [index]
    === Index

currently behave the same. That is a limitation of the makeidx package.