### PR TITLE
[BUG] Respect custom link text for internal references

### DIFF
--- a/lib/asciidoctor/latex/converter.rb
+++ b/lib/asciidoctor/latex/converter.rb
@@ -321,14 +321,11 @@ module Asciidoctor::LaTeX
       case node.type.to_s
 
       when 'xref'
-        refid = node.attributes['refid']
-        if refid and refid[0] == '_'
-          output = "<a href=\##{refid}>#{refid.gsub('_',' ')}</a>"
-        else
+          refid = node.attributes['refid']
           refs = node.parent.document.references[:ids]
           # FIXME: the next line is HACKISH (and it crashes the app when refs[refid]) is nil)
           # FIXME: and with the fix for nil results is even more hackish
-          if !node.text && refs[refid]
+          if !node.text && refid && refs[refid]
             reftext = refs[refid].gsub('.', '')
             reftext = reftext.gsub(/:.*/,'')
             if refid =~ /\Aeq-/
@@ -341,13 +338,10 @@ module Asciidoctor::LaTeX
               output = "<span class='xref'><a href=\##{refid}>#{reftext}</a></span>"
             end
           else
-            output = old_inline_anchor node
+            output = "<span class='xref'>" + old_inline_anchor(node) + "</span>"
           end
-        end
-      when 'link'
-        output = "<a href=#{node.target}>#{node.text}</a>"
       else
-        output =  old_inline_anchor node
+        output = old_inline_anchor node
       end
       output
     end

--- a/lib/asciidoctor/latex/converter.rb
+++ b/lib/asciidoctor/latex/converter.rb
@@ -328,7 +328,7 @@ module Asciidoctor::LaTeX
           refs = node.parent.document.references[:ids]
           # FIXME: the next line is HACKISH (and it crashes the app when refs[refid]) is nil)
           # FIXME: and with the fix for nil results is even more hackish
-          if refs[refid]
+          if !node.text && refs[refid]
             reftext = refs[refid].gsub('.', '')
             reftext = reftext.gsub(/:.*/,'')
             if refid =~ /\Aeq-/

--- a/lib/asciidoctor/latex/node_processors.rb
+++ b/lib/asciidoctor/latex/node_processors.rb
@@ -790,14 +790,14 @@ module Asciidoctor
       # FIXME: the next line is HACKISH (and it crashes the app when refs[refid]) is nil)
       # FIXME: and with the fix for nil results is even more hackish
       # if refs[refid]
-      if refs[refid]
+      if !self.text && refs[refid]
         reftext = refs[refid].gsub('.', '')
         m = reftext.match /(\d*)/
         if m[1] == reftext
           reftext = "(#{reftext})"
         end
       else
-        reftext = ""
+        reftext = self.text
       end
       case self.type
         when :link

--- a/test/examples/html/inline_anchor.html
+++ b/test/examples/html/inline_anchor.html
@@ -1,0 +1,23 @@
+<!-- .basic -->
+<a href="http://www.asciidoctor.org" class="bare">http://www.asciidoctor.org</a>
+
+<!-- .basic_with_text -->
+<a href="irc://irc.freenode.org/#asciidoctor">Asciidoctor IRC channel</a>
+
+<!-- .basic_with_target_blank -->
+<a href="view-source:asciidoctor.org" target="_blank">Asciidoctor homepage</a>
+
+<!-- .basic_with_role -->
+<a href="http://discuss.asciidoctor.org/" class="green"><strong>mailing list</strong></a>
+
+<!-- .xref -->
+The section <span class="xref"><a href="#page-break">[page-break]</a></span> describes how to add a page break.
+
+<!-- .xref_with_text -->
+The section <span class="xref"><a href="#page-break">Page break</a></span> describes how to add a page break.
+
+<!-- .xref_resolved_text -->
+Refer to <span class="xref"><a href="#_section_a">Section A</a></span>.
+
+<!-- .bibref -->
+[<a id="prag"></a>] Andy Hunt &amp; Dave Thomas. The Pragmatic Programmer

--- a/test/examples/tex/inline_anchor.tex
+++ b/test/examples/tex/inline_anchor.tex
@@ -14,7 +14,7 @@
 The section \hyperlink{page-break}{} describes how to add a page break.
 
 %== .xref_with_text ==%
-The section \hyperlink{page-break}{} describes how to add a page break.
+The section \hyperlink{page-break}{Page break} describes how to add a page break.
 
 %== .xref_resolved_text ==%
 Refer to \hyperlink{x-section-a}{Section A}.

--- a/test/html_test.rb
+++ b/test/html_test.rb
@@ -1,8 +1,9 @@
 require 'test_helper'
 
-DocTest.examples_path = ['test/examples/html', 'test/examples/asciidoc-html']
+DocTest.examples_path.unshift 'test/examples/html', 'test/examples/asciidoc-html'
 
 class HtmlTest < DocTest::Test
   converter_opts backend_name: 'html', dialect: 'latex'
-  generate_tests! DocTest::HTML::ExamplesSuite
+  html_suite = DocTest::HTML::ExamplesSuite.new paragraph_xpath: './div/p/node()'
+  generate_tests! html_suite
 end


### PR DESCRIPTION
This fixes a bug that would simply discard custom link texts, for example in

    the <<myref,problem>> is hard

the linked text would not be "problem" but whatever myref points to.