### PR TITLE
Use align/aligned instead of equation/split

### DIFF
--- a/lib/asciidoctor/latex/converter.rb
+++ b/lib/asciidoctor/latex/converter.rb
@@ -383,7 +383,7 @@ module Asciidoctor::LaTeX
       node.title = nil
       number_part = '<td class="equation_number_style">' + "(#{node.caption}) </td>"
       number_part = ["+++ #{number_part} +++"]
-      equation_part = ['+++<td class="equation_content_style";>+++'] + ['\\[\\begin{split}'] + node.lines + ['\\end{split}\\]'] + ['+++</td>+++']
+      equation_part = ['+++<td class="equation_content_style";>+++'] + ['\\[\\begin{aligned}'] + node.lines + ['\\end{aligned}\\]'] + ['+++</td>+++']
       table_style='class="equation_table_style" '
       row_style='class="equation_row_style"'
       if options.include? 'numbered'

--- a/lib/asciidoctor/latex/node_processors.rb
+++ b/lib/asciidoctor/latex/node_processors.rb
@@ -408,11 +408,11 @@ module Asciidoctor
     end
 
     def handle_eqalign
-      content = $tex.env 'split', "#{label_line}#{self.content.strip}"
+      content = $tex.env 'aligned', "#{label_line}#{self.content.strip}"
       if options.include? 'numbered'
-        $tex.env 'equation', content
+        $tex.env 'align', content
       else
-        $tex.env 'equation*', content
+        $tex.env 'align*', content
       end
     end
 

--- a/test/examples/html/env.html
+++ b/test/examples/html/env.html
@@ -88,7 +88,7 @@
   <div class="content">
     <table class="equation_table_style">
       <tr class="equation_row_style">
-        <td class="equation_content_style">\[\begin{split} a &amp;= b + c \\ c &amp;= d + e \\ a &amp;= b + d + e \end{split}\]</td>
+        <td class="equation_content_style">\[\begin{aligned} a &amp;= b + c \\ c &amp;= d + e \\ a &amp;= b + d + e \end{aligned}\]</td>
       </tr>
     </table>
   </div>

--- a/test/examples/tex/eqalign.tex
+++ b/test/examples/tex/eqalign.tex
@@ -1,23 +1,23 @@
 %== .eqalign ==%
-\begin{equation*}
-\begin{split}
+\begin{align*}
+\begin{aligned}
 a &= b + c   \\
 b &= x + y  \\
 a &= x + y + c
-\end{split}
-\end{equation*}
-\begin{equation}
-\begin{split}
+\end{aligned}
+\end{align*}
+\begin{align}
+\begin{aligned}
 \label{foo}
 A &= B + C   \\
 B &= X + Y  \\
 Z &= X + Y + C
-\end{split}
-\end{equation}
-\begin{equation}
-\begin{split}
+\end{aligned}
+\end{align}
+\begin{align}
+\begin{aligned}
 a &= b + c   \\
 b &= x + y  \\
 a &= x + y + c
-\end{split}
-\end{equation}
+\end{aligned}
+\end{align}


### PR DESCRIPTION
This isn't the PR I promised to allow references to equations within environments, but it allows multiple equations on one line, such as:

~~~
[env.equationalign]
--
\curl \vH &= \vj + \vj^e + \pd{\vD}{t} & \quad&\text{Faraday's law}\\
\curl \vE &= - \pd{\vB}{t} && \text{Ampere's law}\\
\div \vB &= 0 && \text{Gauss' electric field law}\\
\div \vD &= q + q^e && \text{Gauss' magnetic field law}.
--
~~~

Note that in the html output this did already work, because Mathjax allows for more than one `&` alignment character in `split` environments.

The PDF output looks exactly the same as the old solution otherwise.

Differences that do exist are not relevant to asciidoctor-latex: https://tex.stackexchange.com/q/187938