### PR TITLE
Relax asciidoctor version constraints to work under asciidoctor 2.0

### DIFF
--- a/asciidoctor-latex.gemspec
+++ b/asciidoctor-latex.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |s|
   s.has_rdoc      = 'yard'
 
   s.required_ruby_version = '>= 2.0'
-  
-  s.add_runtime_dependency 'asciidoctor', '~> 1.5', '>= 1.5.2'
+
+  s.add_runtime_dependency 'asciidoctor', '>= 1.5.2'
   s.add_runtime_dependency 'opal', '~> 0.6.3'
   s.add_runtime_dependency 'htmlentities', '~> 4.3'
 


### PR DESCRIPTION
This extension works under asciidoctor 2.0 and is useful. So it would be nice to relax the version constraints so that we have an asciidoc-to-latex convertor.